### PR TITLE
Update Gradle project name to match repo name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 include ':app'
-rootProject.name='Getstream low-level-client-kotlin-test'
+rootProject.name='doc-sample-android-chat-client-kotlin'


### PR DESCRIPTION
It's hard to identify the project in the IDE menus, as its project name differs from the repo's name. This PR fixes that issue.