### PR TITLE
Fix lifecycle viewmodel version

### DIFF
--- a/samplejava/build.gradle
+++ b/samplejava/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation "com.github.getstream:stream-chat-android:1ab9aa8ae2bde84d5e7a61b767b32dd0c33d05e6"
     implementation "io.coil-kt:coil:1.0.0"
 
-    implementation "androidx.lifecycle:lifecycle-viewmodel:2.3.0-beta1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel:2.3.0-beta01"
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation 'androidx.activity:activity-ktx:1.1.0'

--- a/samplekotlin/build.gradle
+++ b/samplekotlin/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "com.github.getstream:stream-chat-android:1ab9aa8ae2bde84d5e7a61b767b32dd0c33d05e6"
     implementation "io.coil-kt:coil:1.0.0"
 
-    implementation "androidx.lifecycle:lifecycle-viewmodel:2.3.0-beta1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel:2.3.0-beta01"
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation 'androidx.activity:activity-ktx:1.1.0'


### PR DESCRIPTION
2.3.0-beta01 is the correct one. For some reason, 2.3.0-beta1 works fine in debug but it is causing assembleRelease error:
Could not determine the dependencies of task ':samplejava:lintVitalRelease'.
> Could not resolve all artifacts for configuration ':samplejava:debugAndroidTestCompileClasspath'.
   > Could not find androidx.lifecycle:lifecycle-viewmodel:2.3.0-beta1.
     Required by:
         project :samplejava