### PR TITLE
Fixing crash for attachments

### DIFF
--- a/samplekotlin/src/main/AndroidManifest.xml
+++ b/samplekotlin/src/main/AndroidManifest.xml
@@ -20,9 +20,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".ChannelActivity" />
-        <activity android:name=".ChannelActivity2" />
-        <activity android:name=".ChannelActivity3" />
-        <activity android:name=".ChannelActivity4" />
+        <activity android:name=".ChannelActivity"
+            android:theme="@style/AppTheme.NoActionBar"/>
+        <activity android:name=".ChannelActivity2"
+            android:theme="@style/AppTheme.NoActionBar"/>
+        <activity android:name=".ChannelActivity3"
+            android:theme="@style/AppTheme.NoActionBar"/>
+        <activity android:name=".ChannelActivity4"
+            android:theme="@style/AppTheme.NoActionBar"/>
     </application>
 </manifest>

--- a/samplekotlin/src/main/res/values/styles.xml
+++ b/samplekotlin/src/main/res/values/styles.xml
@@ -8,4 +8,12 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <!-- Base application theme. -->
+    <style name="AppTheme.NoActionBar" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Fixes crash for when users click in attachments. This style must be used so `com.google.android.material.card.MaterialCardView` can be used