### PR TITLE
Replace fragment ktx dependency

### DIFF
--- a/samplekotlin/build.gradle
+++ b/samplekotlin/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     // Add new dependencies
     implementation "io.getstream:stream-chat-android-ui-components:4.5.4"
     implementation 'io.coil-kt:coil:1.1.1'
-    implementation "androidx.fragment:fragment-ktx:1.3.0"
+    implementation "androidx.activity:activity-ktx:1.2.0"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'


### PR DESCRIPTION
`fragment-ktx` transitively depends on `activity-ktx`. Only `activity-ktx` library is required for our sample app.