### PR TITLE
Remove ChatUI initialization

### DIFF
--- a/samplejava/src/main/java/com/example/chattutorial/MainActivity.java
+++ b/samplejava/src/main/java/com/example/chattutorial/MainActivity.java
@@ -6,7 +6,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.example.chattutorial.databinding.ActivityMainBinding;
-import com.getstream.sdk.chat.ChatUI;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -30,11 +29,9 @@ public final class MainActivity extends AppCompatActivity {
         ActivityMainBinding binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        // Step 1 - Set up the client for API calls, the domain for offline storage
-        //          and the UI components
+        // Step 1 - Set up the client for API calls and the domain for offline storage
         ChatClient client = new ChatClient.Builder("b67pax5b2wdq", getApplicationContext()).build();
         new ChatDomain.Builder(client, getApplicationContext()).build();
-        new ChatUI.Builder(getApplicationContext()).build();
 
         // Step 2 - Authenticate and connect the user
         User user = new User();

--- a/samplekotlin/src/main/java/com/example/chattutorial/MainActivity.kt
+++ b/samplekotlin/src/main/java/com/example/chattutorial/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.example.chattutorial.databinding.ActivityMainBinding
-import com.getstream.sdk.chat.ChatUI
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.User
@@ -24,11 +23,9 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // Step 1 - Set up the client for API calls, the domain for offline storage
-        //          and the UI components
+        // Step 1 - Set up the client for API calls and the domain for offline storage
         val client = ChatClient.Builder("b67pax5b2wdq", applicationContext).build()
         ChatDomain.Builder(client, applicationContext).build()
-        ChatUI.Builder(applicationContext).build()
 
         // Step 2 - Authenticate and connect the user
         val user = User(


### PR DESCRIPTION
Old `ChatUI` is deprecated, the new one is initialized automatically. Therefore, removing `ChatUI` initialization from our tutorials.