### PR TITLE
Update SDK version to 4.24.0

### DIFF
--- a/samplejava/src/main/res/layout/activity_channel_2.xml
+++ b/samplejava/src/main/res/layout/activity_channel_2.xml
@@ -33,4 +33,5 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/samplejava/src/main/res/layout/attachment_imgur.xml
+++ b/samplejava/src/main/res/layout/attachment_imgur.xml
@@ -27,4 +27,5 @@
         app:layout_constraintEnd_toEndOf="@+id/iv_media_thumb"
         app:layout_constraintStart_toStartOf="@id/iv_media_thumb"
         app:layout_constraintTop_toTopOf="@id/iv_media_thumb" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/samplekotlin/build.gradle
+++ b/samplekotlin/build.gradle
@@ -12,15 +12,6 @@ android {
         targetSdk 31
         versionCode 1
         versionName "1.0"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
     }
 
     // Enable ViewBinding
@@ -31,15 +22,8 @@ android {
 
 dependencies {
     // Add new dependencies
-    implementation "io.getstream:stream-chat-android-ui-components:4.23.0"
-    implementation 'io.coil-kt:coil:1.4.0'
+    implementation "io.getstream:stream-chat-android-ui-components:4.24.0"
+    implementation "com.google.android.material:material:1.4.0"
     implementation "androidx.activity:activity-ktx:1.4.0"
-
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation "io.coil-kt:coil:1.4.0"
 }

--- a/samplekotlin/src/main/res/layout/activity_channel_2.xml
+++ b/samplekotlin/src/main/res/layout/activity_channel_2.xml
@@ -32,4 +32,5 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/samplekotlin/src/main/res/layout/attachment_imgur.xml
+++ b/samplekotlin/src/main/res/layout/attachment_imgur.xml
@@ -27,4 +27,5 @@
         app:layout_constraintEnd_toEndOf="@+id/iv_media_thumb"
         app:layout_constraintStart_toStartOf="@id/iv_media_thumb"
         app:layout_constraintTop_toTopOf="@id/iv_media_thumb" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Update SDK version to `4.24.0` and remove unused dependencies.

- Removed unit test dependencies.
- Removed core, appcompat, constraintlayout dependencies. (They are included in the material library)