### PR TITLE
Fix samplejava compilation error and migrate non-deprecated methods

### DIFF
--- a/samplejava/src/main/java/com/example/chattutorial/ImgurAttachmentFactory.java
+++ b/samplejava/src/main/java/com/example/chattutorial/ImgurAttachmentFactory.java
@@ -15,11 +15,13 @@ import coil.Coil;
 import coil.request.ImageRequest;
 import io.getstream.chat.android.models.Attachment;
 import io.getstream.chat.android.models.Message;
-import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListListenerContainer;
+import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListListeners;
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.BaseAttachmentFactory;
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.InnerAttachmentViewHolder;
 
-/** A custom attachment factory to show an imgur logo if the attachment URL is an imgur image. **/
+/**
+ * A custom attachment factory to show an imgur logo if the attachment URL is an imgur image.
+ **/
 public class ImgurAttachmentFactory extends BaseAttachmentFactory {
 
 
@@ -35,7 +37,7 @@ public class ImgurAttachmentFactory extends BaseAttachmentFactory {
     @Override
     public InnerAttachmentViewHolder createViewHolder(
             @NonNull Message message,
-            @Nullable MessageListListenerContainer listeners,
+            @Nullable MessageListListeners listeners,
             @NonNull ViewGroup parent
     ) {
         Attachment imgurAttachment = containsImgurAttachments(message);

--- a/samplejava/src/main/java/com/example/chattutorial/ImgurAttachmentFactory.java
+++ b/samplejava/src/main/java/com/example/chattutorial/ImgurAttachmentFactory.java
@@ -16,11 +16,11 @@ import coil.request.ImageRequest;
 import io.getstream.chat.android.models.Attachment;
 import io.getstream.chat.android.models.Message;
 import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListListenerContainer;
-import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.AttachmentFactory;
+import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.BaseAttachmentFactory;
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.InnerAttachmentViewHolder;
 
 /** A custom attachment factory to show an imgur logo if the attachment URL is an imgur image. **/
-public class ImgurAttachmentFactory implements AttachmentFactory {
+public class ImgurAttachmentFactory extends BaseAttachmentFactory {
 
 
     // Step 1 - Check whether the message contains an Imgur attachment

--- a/samplekotlin/src/main/java/com/example/chattutorial/ImgurAttachmentFactory.kt
+++ b/samplekotlin/src/main/java/com/example/chattutorial/ImgurAttachmentFactory.kt
@@ -6,7 +6,7 @@ import coil.load
 import com.example.chattutorial.databinding.AttachmentImgurBinding
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Message
-import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListListenerContainer
+import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListListeners
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.AttachmentFactory
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.InnerAttachmentViewHolder
 
@@ -23,10 +23,10 @@ class ImgurAttachmentFactory : AttachmentFactory {
     // over Imgur attachments
     override fun createViewHolder(
         message: Message,
-        listeners: MessageListListenerContainer?,
+        listeners: MessageListListeners?,
         parent: ViewGroup
     ): InnerAttachmentViewHolder {
-        val imgurAttachment = message.attachments.first() { it.isImgurAttachment() }
+        val imgurAttachment = message.attachments.first { it.isImgurAttachment() }
         val binding = AttachmentImgurBinding
             .inflate(LayoutInflater.from(parent.context), null, false)
         return ImgurAttachmentViewHolder(


### PR DESCRIPTION
### Part 1 (commit: 680c838b2430645ebf9d508b9f1fb69c7918e885)
There is currently a compile-time error in the `samplejava` project in the `ImgurAttachmentFactory.java`:
`error: ImgurAttachmentFactory is not abstract and does not override abstract method createViewHolder(Message,MessageListListeners,ViewGroup) in AttachmentFactory`

The problem origin is that the interface `AttachmentFactory` has default implementations for its methods, however those are not recognised when the interface is implemented by a `java` class, and an implementation must be provided for all such methods.

There was already an existing workaround for this case: Use the `BaseAttachmentFactory` abstract class as a base, instead of directly implementing the `AttachmentFactory` -> extending this class solves the issue and we don't need to provide an implementation for all methods.

### Part 2 (commit: 3cdeb97a5f6a76e3614cebe22c88de19f190363b)
Additionally, the `ImgurAttachmentFactory` was still using the now deprecated method: `createViewHolder(message: Message,  listeners: MessageListListenerContainer?, parent: ViewGroup): InnerAttachmentViewHolder`. This method is now replaced with the new `createViewHolder(message: Message,  listeners: MessageListListeners?, parent: ViewGroup): InnerAttachmentViewHolder`