### PR TITLE
Update/stream sdk versions 6.28.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:8.8.2"
+        classpath 'com.android.tools.build:gradle:8.13.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 24 11:31:30 KST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samplejava/build.gradle
+++ b/samplejava/build.gradle
@@ -31,8 +31,8 @@ android {
 
 dependencies {
     // Add new dependencies
-    implementation "io.getstream:stream-chat-android-ui-components:6.28.1"
-    implementation "io.getstream:stream-chat-android-offline:6.28.1"
+    implementation "io.getstream:stream-chat-android-ui-components:6.28.0"
+    implementation "io.getstream:stream-chat-android-offline:6.28.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.8.7"
     implementation "com.google.android.material:material:1.12.0"
     implementation "androidx.activity:activity-ktx:1.10.1"

--- a/samplejava/build.gradle
+++ b/samplejava/build.gradle
@@ -31,8 +31,8 @@ android {
 
 dependencies {
     // Add new dependencies
-    implementation "io.getstream:stream-chat-android-ui-components:6.12.1"
-    implementation "io.getstream:stream-chat-android-offline:6.12.1"
+    implementation "io.getstream:stream-chat-android-ui-components:6.28.1"
+    implementation "io.getstream:stream-chat-android-offline:6.28.1"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.8.7"
     implementation "com.google.android.material:material:1.12.0"
     implementation "androidx.activity:activity-ktx:1.10.1"

--- a/samplekotlin/build.gradle
+++ b/samplekotlin/build.gradle
@@ -32,8 +32,8 @@ android {
 
 dependencies {
     // Add new dependencies
-    implementation "io.getstream:stream-chat-android-ui-components:6.12.1"
-    implementation "io.getstream:stream-chat-android-offline:6.12.1"
+    implementation "io.getstream:stream-chat-android-ui-components:6.28.1"
+    implementation "io.getstream:stream-chat-android-offline:6.28.1"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.8.7"
     implementation "com.google.android.material:material:1.12.0"
     implementation "androidx.activity:activity-ktx:1.10.1"

--- a/samplekotlin/build.gradle
+++ b/samplekotlin/build.gradle
@@ -32,8 +32,8 @@ android {
 
 dependencies {
     // Add new dependencies
-    implementation "io.getstream:stream-chat-android-ui-components:6.28.1"
-    implementation "io.getstream:stream-chat-android-offline:6.28.1"
+    implementation "io.getstream:stream-chat-android-ui-components:6.28.0"
+    implementation "io.getstream:stream-chat-android-offline:6.28.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.8.7"
     implementation "com.google.android.material:material:1.12.0"
     implementation "androidx.activity:activity-ktx:1.10.1"


### PR DESCRIPTION
Updated both `samplejava` and `samplekotlin` apps' Stream Chat SDK version to 6.28.0 and verified the functionality of the application. 